### PR TITLE
feat: make name set iterable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,4 +43,4 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_API_TOKEN }}
 
       - name: Publish to JSR
-        run: npx jsr publish
+        run: npx jsr publish --allow-dirty

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,14 @@ This file contains the documentation on the notable changes and bug fixes, and
 is formatted following this [standard](https://keepachangelog.com/en/1.0.0/).
 This project also adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.1.0] - 2025-12-06
+
+**Added**:
+
+- Made the name set iterable (i.e., for-of statements).
+- Made types flexible so devs aren’t boxed into enums.
+- Refactored codebasea accordingly to maintain backward compatibility (no breaking changes).
+
 ## [2.0.2] - 2025-12-02
 
 **Fixed**:
@@ -193,6 +201,7 @@ This project also adheres to [Semantic Versioning](https://semver.org/).
 
 Initial version
 
+[2.1.0]: https://github.com/ralflorent/namefully/compare/v2.0.2...v2.1.0
 [2.0.2]: https://github.com/ralflorent/namefully/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/ralflorent/namefully/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/ralflorent/namefully/compare/v1.3.0...v2.0.0

--- a/example/advanced.ts
+++ b/example/advanced.ts
@@ -11,7 +11,7 @@ function main() {
   builder.add(Name.prefix('Mr'));
 
   // Build the name with options if needed
-  name = builder.build({ title: Title.US })
+  name = builder.build({ title: Title.US });
   console.log(name.full); // Mr. Nikola Tesla
 }
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@ralflorent/namefully",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Handle personal names in a particular order, way, or shape.",
   "keywords": ["format", "parse", "human", "personal", "family", "name"],
   "exports": "./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "namefully",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Handle personal names in a particular order, way, or shape.",
   "author": "Ralph Florent",
   "license": "MIT",

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,8 @@ as `FirstName`, `LastName`, or `Name` that may not often follow the same pattern
 rule or behavior in your application.
 
 Below are enlisted the options supported by `namefully`.
+> All enums can be provided as `string` as well. There's no need to bring them in
+> when using TypeScript.
 
 ### orderedBy
 
@@ -108,7 +110,7 @@ const name1 = new Namefully('Smith John Joe', { orderedBy: NameOrder.LAST_NAME }
 console.log(name1.last); // Smith
 
 // 'Edison' is the surname in this string array case
-const name2 = new Namefully(['Edison', 'Thomas'], { orderedBy: NameOrder.LAST_NAME });
+const name2 = new Namefully(['Edison', 'Thomas'], { orderedBy: 'lastname' });
 console.log(name2.first); // Thomas
 ```
 
@@ -119,7 +121,7 @@ console.log(name2.first); // Thomas
 
 ```ts
 // 'Smith' is the surname in this raw string case
-const name = new Namefully('Smith John Joe', { orderedBy: NameOrder.LAST_NAME });
+const name = new Namefully('Smith John Joe', { orderedBy: 'lastname' });
 console.log(name.fullName()); // Smith John Joe
 
 // Now alter the order by choosing the given name first
@@ -134,7 +136,7 @@ _Only valid for raw string values_, this option indicates how to split the parts
 of a raw string name under the hood.
 
 ```ts
-const name = new Namefully('John,Smith', { separator: Separator.COMMA });
+const name = new Namefully('John,Smith', { separator: ',' });
 console.log(name.full); // John Smith
 ```
 
@@ -222,11 +224,11 @@ To sum it all up, the default values are:
 Customize your own parser to indicate the full name yourself.
 
 ```ts
-import { Config, FullName, Namefully, Parser } from 'namefully';
+import { IConfig, FullName, Namefully, Parser } from 'namefully';
 
 // Suppose you want to cover this '#' separator
 class SimpleParser extends Parser<string> {
-  parse(options: Partial<Config>): FullName {
+  parse(options: IConfig): FullName {
     const [firstName, lastName] = this.raw.split('#');
     return FullName.parse({ firstName, lastName }, Config.merge(options));
   }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,5 +1,5 @@
 import { Name } from './name.js';
-import { Config } from './config.js';
+import { IConfig } from './config.js';
 import { Namefully } from './namefully.js';
 import { ArrayNameValidator } from './validator.js';
 
@@ -80,7 +80,7 @@ abstract class Builder<T, I> {
   }
 
   /** Builds the desired instance with optional parameters. */
-  abstract build(options?: Partial<Config>): I;
+  abstract build(options?: IConfig): I;
 }
 
 /**
@@ -141,7 +141,7 @@ export class NameBuilder extends Builder<Name, Namefully> {
    * Regardless of how the names are added, both first and last names must exist
    * to complete a fine build. Otherwise, it throws a NameError.
    */
-  build(config?: Partial<Config>): Namefully {
+  build(config?: IConfig): Namefully {
     this.prebuild?.();
 
     const names = [...this.queue];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-export const VERSION = '2.0.2';
+export const VERSION = '2.1.0';
 export const MIN_NUMBER_OF_NAME_PARTS = 2;
 export const MAX_NUMBER_OF_NAME_PARTS = 5;
 export const ALLOWED_FORMAT_TOKENS = [

--- a/src/fixtures/helpers.ts
+++ b/src/fixtures/helpers.ts
@@ -1,12 +1,11 @@
-import { Config } from '../config.js';
-import { FullName } from '../fullname.js';
-import { FirstName, LastName, Name, JsonName } from '../name.js';
-import { Namefully } from '../namefully.js';
 import { Parser } from '../parser.js';
-import { NameOrder, Separator, Surname, Title } from '../types.js';
+import { FullName } from '../fullname.js';
+import { Namefully } from '../namefully.js';
+import { IConfig, Config } from '../config.js';
+import { FirstName, LastName, Name, JsonName } from '../name.js';
 
 export class SimpleParser extends Parser<string> {
-  parse(options: Partial<Config>): FullName {
+  parse(options: IConfig): FullName {
     const [firstName, lastName] = this.raw.split('#');
     return FullName.parse({ firstName, lastName }, Config.merge(options));
   }
@@ -19,12 +18,12 @@ export function findNameCase(name: string): Namefully {
 
 interface NameCase {
   name: string | string[] | Name[] | JsonName;
-  options: Partial<Config>;
+  options: IConfig;
 }
 
 const NAME_CASES: { [key: string]: NameCase } = {
   simpleName: { name: 'John Smith', options: Config.create('simpleName') },
-  byLastName: { name: 'Obama Barack', options: Config.merge({ name: 'byLastName', orderedBy: NameOrder.LAST_NAME }) },
+  byLastName: { name: 'Obama Barack', options: Config.merge({ name: 'byLastName', orderedBy: 'lastname' }) },
   manyFirstNames: {
     name: [new FirstName('Daniel', 'Michael', 'Blake'), new LastName('Day-Lewis')],
     options: Config.create('manyFirstNames'),
@@ -41,11 +40,11 @@ const NAME_CASES: { [key: string]: NameCase } = {
   },
   manyLastNames: {
     name: [new FirstName('Shakira', 'Isabel'), new LastName('Mebarak', 'Ripoll')],
-    options: Config.merge({ name: 'manyLastNames', surname: Surname.MOTHER }),
+    options: Config.merge({ name: 'manyLastNames', surname: 'mother' }),
   },
   withTitling: {
     name: { prefix: 'Dr', firstName: 'Albert', lastName: 'Einstein' },
-    options: Config.merge({ name: 'withTitling', title: Title.US }),
+    options: Config.merge({ name: 'withTitling', title: 'period' }),
   },
   withEnding: {
     name: { firstName: 'Fabrice', lastName: 'Piazza', suffix: 'Ph.D' },
@@ -53,7 +52,7 @@ const NAME_CASES: { [key: string]: NameCase } = {
   },
   withSeparator: {
     name: 'Thiago, Da Silva',
-    options: Config.merge({ name: 'withSeparator', separator: Separator.COMMA }),
+    options: Config.merge({ name: 'withSeparator', separator: ',' }),
   },
   noBypass: {
     name: {
@@ -66,7 +65,7 @@ const NAME_CASES: { [key: string]: NameCase } = {
       name: 'noBypass',
       bypass: false,
       ending: true,
-      title: Title.US,
+      title: 'us',
     }),
   },
 };

--- a/src/fullname.spec.ts
+++ b/src/fullname.spec.ts
@@ -77,6 +77,27 @@ describe('FullName', () => {
     expect(fullName.has(Namon.LAST_NAME)).toBe(true);
     expect(fullName.has(Namon.SUFFIX)).toBe(false);
   });
+
+  test('.toIterable() returns sequence of name parts', () => {
+    fullName = new FullName()
+      .setPrefix(prefix)
+      .setFirstName(firstName)
+      .setMiddleName(middleName)
+      .setLastName(lastName)
+      .setSuffix(suffix);
+
+    const parts = fullName[Symbol.iterator]();
+    expect(Name.prefix('Mr').equal(parts.next().value)).toBe(true);
+    expect(Name.first('John').equal(parts.next().value)).toBe(true);
+    expect(Name.middle('Ben').equal(parts.next().value)).toBe(true);
+    expect(Name.middle('Carl').equal(parts.next().value)).toBe(true);
+    expect(Name.last('Smith').equal(parts.next().value)).toBe(true);
+    expect(Name.suffix('Ph.D').equal(parts.next().value)).toBe(true);
+
+    const over = parts.next();
+    expect(over.done).toBe(true);
+    expect(over.value).toBe(undefined);
+  });
 });
 
 function runExpectations(fullName: FullName) {

--- a/src/name.ts
+++ b/src/name.ts
@@ -1,6 +1,7 @@
+import { IConfig } from './config.js';
 import { InputError } from './error.js';
-import { CapsRange, Namon, Surname } from './types.js';
 import { capitalize, decapitalize } from './utils.js';
+import { CapsRange, Namon, Surname, TypeMatcher } from './types.js';
 
 /** Representation of a string type name with some extra capabilities. */
 export class Name {
@@ -195,6 +196,7 @@ export class FirstName extends Name {
 /** Representation of a last name with some extra functionality. */
 export class LastName extends Name {
   #mother?: string;
+  format!: Surname;
 
   /**
    * Creates an extended version of `Name` and flags it as a last name `type`.
@@ -202,14 +204,11 @@ export class LastName extends Name {
    * Some people may keep their @param mother's surname and want to keep a clear cut
    * from their @param father's surname. However, there are no clear rules about it.
    */
-  constructor(
-    father: string,
-    mother?: string,
-    readonly format = Surname.FATHER,
-  ) {
+  constructor(father: string, mother?: string, format?: IConfig['surname']) {
     super(father, Namon.LAST_NAME);
     this.validate(mother);
     this.#mother = mother;
+    this.format = TypeMatcher.surname(format ?? '', Surname.FATHER);
   }
 
   /** The surname inherited from the father side. */
@@ -252,9 +251,10 @@ export class LastName extends Name {
     }
   }
 
-  initials(format?: Surname): string[] {
+  initials(format?: IConfig['surname']): string[] {
     const inits: string[] = [];
-    switch (format ?? this.format) {
+    format = TypeMatcher.surname(format ?? this.format);
+    switch (format) {
       case Surname.HYPHENATED:
       case Surname.ALL:
         inits.push(this.initial);
@@ -284,7 +284,7 @@ export class LastName extends Name {
   }
 
   /** Makes a copy of the current name. */
-  copyWith(values?: { father?: string; mother?: string; format?: Surname }): LastName {
+  copyWith(values?: { father?: string; mother?: string; format?: IConfig['surname'] }): LastName {
     return new LastName(values?.father ?? this.value, values?.mother ?? this.mother, values?.format ?? this.format);
   }
 }

--- a/src/namefully.spec.ts
+++ b/src/namefully.spec.ts
@@ -1,11 +1,11 @@
 import { Config } from './config.js';
 import { NameError } from './error.js';
-import { FirstName, LastName, Name } from './name.js';
+import { NameIndex } from './utils.js';
 import { Namefully } from './namefully.js';
 import { NameBuilder } from './builder.js';
-import { Flat, NameOrder, NameType, Namon, Separator, Surname, Title } from './types.js';
+import { FirstName, LastName, Name } from './name.js';
 import { SimpleParser, findNameCase } from './fixtures/helpers.js';
-import { NameIndex } from './utils.js';
+import { Flat, NameOrder, NameType, Namon, Separator, Surname, Title } from './types.js';
 
 describe('Namefully', () => {
   describe('(default settings)', () => {
@@ -15,23 +15,55 @@ describe('Namefully', () => {
       name = new Namefully('Mr John Ben Smith Ph.D', Config.create('generic'));
     });
 
+    test('.parts returns the name components as a sequence', () => {
+      for (const part of name.parts) {
+        expect(part).toBeInstanceOf(Name);
+      }
+      expect(Array.from(name.parts).length).toBe(5);
+    });
+
+    test('.[Symbol.iterator]() returns sequence of name parts', () => {
+      const parts = name[Symbol.iterator]();
+      expect(Name.prefix('Mr').equal(parts.next().value)).toBe(true);
+      expect(Name.first('John').equal(parts.next().value)).toBe(true);
+      expect(Name.middle('Ben').equal(parts.next().value)).toBe(true);
+      expect(Name.last('Smith').equal(parts.next().value)).toBe(true);
+      expect(Name.suffix('Ph.D').equal(parts.next().value)).toBe(true);
+
+      const over = parts.next();
+      expect(over.done).toBe(true);
+      expect(over.value).toBe(undefined);
+    });
+
     test('.has() determines if the full name has a specific namon', () => {
       expect(name.has(Namon.PREFIX)).toBe(true);
       expect(name.has(Namon.SUFFIX)).toBe(true);
       expect(name.has(Namon.MIDDLE_NAME)).toBe(true);
       expect(name.hasMiddle).toBe(true);
+
+      expect(name.has('firstName')).toBe(true);
+      expect(name.has('lastName')).toBe(true);
+      expect(name.has('middle')).toBe(false); // unknown namon key.
     });
 
     test('.toString() returns a String version of the full name', () => {
       expect(name.toString()).toBe('Mr John Ben Smith Ph.D');
     });
 
-    test('.equal() checks whether two names are equal', () => {
-      expect(name.equal(new Namefully('Mr John Ben Smith Ph.D'))).toBe(true);
-      expect(name.equal(new Namefully('Mr John Ben Smith'))).toBe(false);
+    test('.equal() checks whether two names are equal from a raw-string perspective', () => {
+      const names = [Name.prefix('Mr'), new FirstName('John', 'Ben'), new LastName('Smith'), Name.suffix('Ph.D')];
+      expect(name.equal(new Namefully(names))).toBe(true);
+      expect(name.equal(new Namefully(names.slice(1)))).toBe(false);
     });
 
-    test('get(). gets the raw form of a name', () => {
+    test('.deepEqual() checks whether two names are equal from a component perspective', () => {
+      const name1 = new Namefully('John Ben Smith');
+      const name2 = new Namefully([new FirstName('John', 'Ben'), new LastName('Smith')]);
+      expect(name1.equal(name2)).toBe(true);
+      expect(name1.deepEqual(name2)).toBe(false);
+    });
+
+    test('.get() gets the raw form of a name', () => {
       expect(name.config).toBeDefined();
       expect(name.get(Namon.PREFIX)).toBeInstanceOf(Name);
       expect(name.get(Namon.FIRST_NAME)).toBeInstanceOf(FirstName);
@@ -40,6 +72,11 @@ describe('Namefully', () => {
 
       const middles = name.get(Namon.MIDDLE_NAME) as Name[];
       middles.forEach((n) => expect(n).toBeInstanceOf(Name));
+
+      expect(name.get('prefix')).toBeInstanceOf(Name);
+      expect(name.get('firstName')).toBeInstanceOf(FirstName);
+      expect(name.get('lastName')).toBeInstanceOf(LastName);
+      expect(name.get('suffix')).toBeInstanceOf(Name);
     });
 
     test('.json() returns a json version of the full name', () => {
@@ -420,6 +457,25 @@ describe('Namefully', () => {
           bypass: true,
           ending: true,
           surname: Surname.HYPHENATED,
+        }),
+      );
+      expect(
+        Config.merge({
+          orderedBy: 'lastname',
+          separator: 'colon',
+          title: 'period',
+          surname: '*',
+          ending: true,
+        }),
+      ).toEqual(
+        expect.objectContaining({
+          name: 'default',
+          orderedBy: NameOrder.LAST_NAME,
+          separator: Separator.COLON,
+          title: Title.US,
+          bypass: true,
+          ending: true,
+          surname: Surname.ALL,
         }),
       );
     });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,7 +1,7 @@
-import { Config } from './config.js';
 import { NameIndex } from './utils.js';
 import { InputError } from './error.js';
 import { FullName } from './fullname.js';
+import { Config, IConfig } from './config.js';
 import { Namon, Nullable, Separator } from './types.js';
 import { FirstName, LastName, Name, JsonName } from './name.js';
 import { ArrayStringValidator, ArrayNameValidator, NamaValidator } from './validator.js';
@@ -58,11 +58,11 @@ export abstract class Parser<T = unknown> {
    * Parses the raw data into a `FullName` while considering some options.
    * @param options for additional configuration to apply.
    */
-  abstract parse(options?: Partial<Config>): FullName;
+  abstract parse(options?: IConfig): FullName;
 }
 
 export class StringParser extends Parser<string> {
-  parse(options: Partial<Config>): FullName {
+  parse(options: IConfig): FullName {
     const config = Config.merge(options);
     const names = this.raw.split(config.separator.token);
     return new ArrayStringParser(names).parse(options);
@@ -70,7 +70,7 @@ export class StringParser extends Parser<string> {
 }
 
 export class ArrayStringParser extends Parser<string[]> {
-  parse(options: Partial<Config>): FullName {
+  parse(options: IConfig): FullName {
     const config = Config.merge(options);
     const fullName = new FullName(config);
 
@@ -97,7 +97,7 @@ export class ArrayStringParser extends Parser<string[]> {
 }
 
 export class NamaParser extends Parser<JsonName> {
-  parse(options: Partial<Config>): FullName {
+  parse(options: IConfig): FullName {
     const config = Config.merge(options);
     const names = new Map<Namon, string>(
       Object.entries(this.raw).map(([key, value]) => {
@@ -123,7 +123,7 @@ export class NamaParser extends Parser<JsonName> {
 }
 
 export class ArrayNameParser extends Parser<Name[]> {
-  parse(options: Partial<Config>): FullName {
+  parse(options: IConfig): FullName {
     const config = Config.merge(options);
     const fullName = new FullName(config);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import { NameOrder, CapsRange } from './types.js';
+import { IConfig } from './config.js';
+import { NameOrder, CapsRange, TypeMatcher } from './types.js';
 import { MIN_NUMBER_OF_NAME_PARTS, MAX_NUMBER_OF_NAME_PARTS } from './constants.js';
 
 /**
@@ -52,8 +53,8 @@ export class NameIndex {
    * Gets the name index for a list of names based on the `count` of elements
    * and their `order` of appearance.
    */
-  static when(order: NameOrder, count = 2): NameIndex {
-    if (order === NameOrder.FIRST_NAME) {
+  static when(order: IConfig['orderedBy'], count = 2): NameIndex {
+    if (TypeMatcher.nameOrder(order ?? '') === NameOrder.FIRST_NAME) {
       switch (count) {
         case 2: // first name + last name
           return new NameIndex(-1, 0, -1, 1, -1);


### PR DESCRIPTION
### Makes the name set iterable (i.e., for-of statements).

This is similar to `parts` with the exception that all name components are returned as `Name` classes (instead of their natural form - e.g., `FirstName` or `LastName`) to maintain certain homogeneity and consistency across each name piece.

This PR also includes changes to support flexible types instead of being forced to import enums (`Separator`, `NameOrder`, etc.) to customize the behavior of the name components via `Config`. For example, working with names ordered by family name should be as easy as doing this:
```js
import namefully from 'namefully';

const barack = namefully('Obama Barack', { orderedBy: 'lastname' });
console.log(barack.initials({ orderedBy: 'firstname' }); // ['B', 'O']
```